### PR TITLE
remove direct comms with xlm for teller

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -618,7 +618,7 @@ an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
 
- END OF TERMS AND CONDITIONS
+END OF TERMS AND CONDITIONS
 
 Copyright 2019-present Varunram Ganesh
 Copyright 2019-present MIT Digital Currency Initiative

--- a/teller/commands.go
+++ b/teller/commands.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	utils "github.com/Varunram/essentials/utils"
-	xlm "github.com/YaleOpenLab/openx/chains/xlm"
 	"github.com/fatih/color"
 )
 
@@ -64,7 +63,7 @@ func ParseInput(input []string) {
 			fmt.Println("USAGE: receive xlm")
 			return
 		}
-		err := xlm.GetXLM(RecpPublicKey)
+		err := askXLM() // the rpc allows people to only ask for coins to their publickey, so we should be okay here
 		if err != nil {
 			log.Println(err)
 		}
@@ -88,9 +87,9 @@ func ParseInput(input []string) {
 
 			switch subsubcommand {
 			case "xlm":
-				balance, err = xlm.GetNativeBalance(RecpPublicKey)
+				balance, err = getNativeBalance()
 			default:
-				balance, err = xlm.GetAssetBalance(RecpPublicKey, subcommand)
+				balance, err = getAssetBalance(subcommand)
 			}
 
 			if err != nil {

--- a/teller/helpers.go
+++ b/teller/helpers.go
@@ -14,17 +14,10 @@ import (
 
 	ipfs "github.com/Varunram/essentials/ipfs"
 	utils "github.com/Varunram/essentials/utils"
-	xlm "github.com/YaleOpenLab/openx/chains/xlm"
 	//	rpc "github.com/YaleOpenLab/openx/rpc"
 	consts "github.com/YaleOpenLab/opensolar/consts"
 	oracle "github.com/YaleOpenLab/opensolar/oracle"
 )
-
-// BlockStamp gets the latest block hash
-func blockStamp() (string, error) {
-	hash, err := xlm.GetLatestBlockHash()
-	return hash, err
-}
 
 // refreshLogin runs once every 5 minutes in order to fetch the latest recipient details
 // for eg, if the recipient loads his balance on the platform, we need it to be reflected on
@@ -46,7 +39,7 @@ func endHandler() error {
 	log.Println("Gracefully shutting down, please do not press any button in the process")
 	var err error
 
-	NowHash, err = blockStamp()
+	NowHash, err = getLatestBlockHash()
 	if err != nil {
 		log.Println(err)
 	}
@@ -84,11 +77,11 @@ func splitAndSend2Tx(memo string) (string, string, error) {
 	// 10 padding chars + 46 (ipfs hash length) characters
 	firstHalf := memo[:28]
 	secondHalf := memo[28:]
-	_, tx1, err := xlm.SendXLM(RecpPublicKey, 1, RecpSeed, firstHalf)
+	tx1, err := sendXLM(RecpPublicKey, 1, firstHalf)
 	if err != nil {
 		return "", "", err
 	}
-	_, tx2, err := xlm.SendXLM(RecpPublicKey, 1, RecpSeed, secondHalf)
+	tx2, err := sendXLM(RecpPublicKey, 1, secondHalf)
 	if err != nil {
 		return "", "", err
 	}
@@ -143,12 +136,12 @@ func updateState(trigger bool) {
 		// But we do need to track this somehow, so maybe hash the device id and "STATUPS: "
 		// so we can track if but others viewing the blockchain can't (since the deviceId is assumed
 		// to be unique)
-		_, hash1, err := xlm.SendXLM(RecpPublicKey, float64(utils.Unix()), RecpSeed, ipfsHash[:28])
+		hash1, err := sendXLM(RecpPublicKey, float64(utils.Unix()), ipfsHash[:28])
 		if err != nil {
 			log.Println(err)
 		}
 
-		_, hash2, err := xlm.SendXLM(RecpPublicKey, float64(utils.Unix()), RecpSeed, ipfsHash[29:])
+		hash2, err := sendXLM(RecpPublicKey, float64(utils.Unix()), ipfsHash[29:])
 		if err != nil {
 			log.Println(err)
 		}

--- a/teller/requests.go
+++ b/teller/requests.go
@@ -422,3 +422,102 @@ func testSwytch() {
 
 	log.Println("Energy Attribute data: ", x6)
 }
+
+func sendXLM(publickey string, amountx float64, memo string) (string, error) {
+	amount, err := utils.ToString(amountx)
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
+
+	body := ApiUrl + "/user/sendxlm?username=" + Username + "&token=" + Token + "&destination=" +
+		publickey + "&amount=" + amount + "&seedpwd=" + LocalSeedPwd
+
+	data, err := erpc.GetRequest(body)
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
+
+	var txhash string
+	err = json.Unmarshal(data, &txhash)
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
+
+	return txhash, err
+}
+
+func getLatestBlockHash() (string, error) {
+	data, err := erpc.GetRequest(ApiUrl + "/user/latestblockhash?username=" + Username + "&token=" + Token)
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
+
+	var blockhash string
+	err = json.Unmarshal(data, &blockhash)
+	if err != nil {
+		log.Println(err)
+		return "", err
+	}
+
+	return blockhash, err
+}
+
+func askXLM() error {
+	data, err := erpc.GetRequest(ApiUrl + "/user/askxlm?username=" + Username + "&token=" + Token)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	var status erpc.StatusResponse
+	err = json.Unmarshal(data, &status)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	if status.Code == 200 {
+		return nil
+	}
+
+	return err
+}
+
+func getNativeBalance() (float64, error) {
+	data, err := erpc.GetRequest(ApiUrl + "/user/balance/xlm?username=" + Username + "&token=" + Token)
+	if err != nil {
+		log.Println(err)
+		return -1, err
+	}
+
+	var balance float64
+	err = json.Unmarshal(data, &balance)
+	if err != nil {
+		log.Println(err)
+		return -1, err
+	}
+
+	return balance, err
+}
+
+func getAssetBalance(asset string) (float64, error) {
+	data, err := erpc.GetRequest(ApiUrl + "/user/balance/asset?username=" + Username + "&token=" + Token +
+		"asset=" + asset)
+	if err != nil {
+		log.Println(err)
+		return -1, err
+	}
+
+	var balance float64
+	err = json.Unmarshal(data, &balance)
+	if err != nil {
+		log.Println(err)
+		return -1, err
+	}
+
+	return balance, err
+}


### PR DESCRIPTION
the teller communicates solely with the opensolar instance now. While
this has a tradeoff in terms of trust, the teller itself is a trusted
device, so this assumption doesn't increase the base layer of assumption
wrt trust