### PR TITLE
add escrow refill functions to guarantor

### DIFF
--- a/core/guarantor.go
+++ b/core/guarantor.go
@@ -1,8 +1,115 @@
 package core
 
+import (
+	"github.com/pkg/errors"
+	"log"
+
+	utils "github.com/Varunram/essentials/utils"
+	consts "github.com/YaleOpenLab/opensolar/consts"
+	xlm "github.com/YaleOpenLab/openx/chains/xlm"
+	assets "github.com/YaleOpenLab/openx/chains/xlm/assets"
+	wallet "github.com/YaleOpenLab/openx/chains/xlm/wallet"
+)
+
 // AddFirstLossGuarantee adds the given entity as a first loss guarantor
 func (a *Entity) AddFirstLossGuarantee(seedpwd string, amount float64) error {
+	if !a.Guarantor {
+		log.Println("caller not guarantor")
+		return errors.New("caller not guarantor, quitting")
+	}
+
 	a.FirstLossGuarantee = seedpwd
 	a.FirstLossGuaranteeAmt = amount
 	return a.Save()
+}
+
+func (a *Entity) RefillEscrowAsset(projIndex int, asset string, amount float64, seedpwd string) error {
+	if !a.Guarantor {
+		log.Println("caller not guarantor")
+		return errors.New("caller not guarantor, quitting")
+	}
+
+	project, err := RetrieveProject(projIndex)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	balancex, err := xlm.GetAssetBalance(a.U.StellarWallet.PublicKey, asset)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	balance, err := utils.ToFloat(balancex)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	if balance < amount {
+		log.Println("guarantor does not required amount, refilling what amount they have")
+		amount = balance - 1.0 // fees
+	}
+
+	seed, err := wallet.DecryptSeed(a.U.StellarWallet.EncryptedSeed, seedpwd)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	_, txhash, err := assets.SendAsset(consts.StablecoinCode, consts.StablecoinPublicKey,
+		project.EscrowPubkey, amount, seed, "guarantor refund")
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	log.Println("txhash: ", txhash)
+	return nil
+}
+
+func (a *Entity) RefillEscrowXLM(projIndex int, amount float64, seedpwd string) error {
+	if !a.Guarantor {
+		log.Println("caller not guarantor")
+		return errors.New("caller not guarantor, quitting")
+	}
+
+	project, err := RetrieveProject(projIndex)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	balancex, err := xlm.GetNativeBalance(a.U.StellarWallet.PublicKey)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	balance, err := utils.ToFloat(balancex)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	if balance < amount {
+		log.Println("guarantor does not required amount, refilling what amount they have")
+		amount = balance - 1.0 // fees
+	}
+
+	seed, err := wallet.DecryptSeed(a.U.StellarWallet.EncryptedSeed, seedpwd)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	_, txhash, err := xlm.SendXLM(project.EscrowPubkey, amount, seed, "guarantor refund")
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	log.Println("txhash: ", txhash)
+	return nil
 }

--- a/rpc/developer.go
+++ b/rpc/developer.go
@@ -14,10 +14,10 @@ func setupDeveloperRPCs() {
 }
 
 var DevRPC = map[int][]string{
-	1: []string{"/developer/withdraw", "POST", "amount", "projIndex"}, // GET
+	1: []string{"/developer/withdraw", "POST", "amount", "projIndex"}, // POST
 }
 
-// getStage1Contracts gets a list of all the originated contracts on the platform
+// withdrawdeveloper can be called by a developer wishing to withdraw funds from the platfomr
 func withdrawdeveloper() {
 	http.HandleFunc(DevRPC[1][0], func(w http.ResponseWriter, r *http.Request) {
 		prepDev, err := entityValidateHelper(w, r, DevRPC[1][2:], DevRPC[1][1])

--- a/rpc/guarantor.go
+++ b/rpc/guarantor.go
@@ -1,0 +1,99 @@
+package rpc
+
+import (
+	"log"
+	"net/http"
+
+	erpc "github.com/Varunram/essentials/rpc"
+	utils "github.com/Varunram/essentials/utils"
+	// core "github.com/YaleOpenLab/opensolar/core"
+)
+
+func setupGuarantorRPCs() {
+	depositXLMGuarantor()
+	depositAssetGuarantor()
+}
+
+var GuaRPC = map[int][]string{
+	1: []string{"/guarantor/deposit/xlm", "POST", "amount", "projIndex", "seedpwd"},                // POST
+	2: []string{"/guarantor/deposit/asset", "POST", "amount", "projIndex", "seedpwd", "assetCode"}, // POST
+}
+
+// depositXLMGuarantor is called by a guarantor when they wish to refill the escrow account with xlm
+func depositXLMGuarantor() {
+	http.HandleFunc(GuaRPC[1][0], func(w http.ResponseWriter, r *http.Request) {
+		prepEntity, err := entityValidateHelper(w, r, GuaRPC[1][2:], GuaRPC[1][1])
+		if err != nil {
+			log.Println("Error while validating entity", err)
+			erpc.ResponseHandler(w, erpc.StatusUnauthorized)
+			return
+		}
+
+		amountx := r.FormValue("amount")
+		projIndexx := r.FormValue("projIndex")
+		seedpwd := r.FormValue("seedpwd")
+
+		projIndex, err := utils.ToInt(projIndexx)
+		if err != nil {
+			log.Println(err)
+			erpc.ResponseHandler(w, erpc.StatusBadRequest)
+			return
+		}
+
+		amount, err := utils.ToFloat(amountx)
+		if err != nil {
+			log.Println(err)
+			erpc.ResponseHandler(w, erpc.StatusBadRequest)
+			return
+		}
+
+		err = prepEntity.RefillEscrowXLM(projIndex, amount, seedpwd)
+		if err != nil {
+			log.Println(err)
+			erpc.ResponseHandler(w, erpc.StatusInternalServerError)
+			return
+		}
+
+		erpc.ResponseHandler(w, erpc.StatusOK)
+	})
+}
+
+// depositAssetGuarantor is called by a guarantor when they wish to refill the escrow account with an asset
+func depositAssetGuarantor() {
+	http.HandleFunc(GuaRPC[2][0], func(w http.ResponseWriter, r *http.Request) {
+		prepEntity, err := entityValidateHelper(w, r, GuaRPC[2][2:], GuaRPC[2][1])
+		if err != nil {
+			log.Println("Error while validating entity", err)
+			erpc.ResponseHandler(w, erpc.StatusUnauthorized)
+			return
+		}
+
+		amountx := r.FormValue("amount")
+		projIndexx := r.FormValue("projIndex")
+		seedpwd := r.FormValue("seedpwd")
+		asset := r.FormValue("assetCode")
+
+		projIndex, err := utils.ToInt(projIndexx)
+		if err != nil {
+			log.Println(err)
+			erpc.ResponseHandler(w, erpc.StatusBadRequest)
+			return
+		}
+
+		amount, err := utils.ToFloat(amountx)
+		if err != nil {
+			log.Println(err)
+			erpc.ResponseHandler(w, erpc.StatusBadRequest)
+			return
+		}
+
+		err = prepEntity.RefillEscrowAsset(projIndex, asset, amount, seedpwd)
+		if err != nil {
+			log.Println(err)
+			erpc.ResponseHandler(w, erpc.StatusInternalServerError)
+			return
+		}
+
+		erpc.ResponseHandler(w, erpc.StatusOK)
+	})
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -131,6 +131,7 @@ func StartServer(portx int, insecure bool) {
 	setupStagesHandlers()
 	setupAdminHandlers()
 	setupDeveloperRPCs()
+	setupGuarantorRPCs()
 
 	port, err := utils.ToString(portx)
 	if err != nil {


### PR DESCRIPTION
guarantor can now refill in XLM / relevant asset. TODO: should add RPC routes.